### PR TITLE
Implement retain messages feature.

### DIFF
--- a/src/Amazon.SQS.ExtendedClient.Tests/Constants.cs
+++ b/src/Amazon.SQS.ExtendedClient.Tests/Constants.cs
@@ -3,5 +3,7 @@
     public static class Constants
     {
         public const string CustomPrefix = "CustomPrefix";
+
+        public const string HandleTail = "_handle_";
     }
 }

--- a/src/Amazon.SQS.ExtendedClient.Tests/When_Client_Deletes_Batch.cs
+++ b/src/Amazon.SQS.ExtendedClient.Tests/When_Client_Deletes_Batch.cs
@@ -14,45 +14,73 @@
         [Test]
         public void Long_Messages_They_Are_Deleted_From_S3_And_SQS()
         {
-            var handleTail = "_handle_";
             var s3Key = Guid.NewGuid().ToString("N");
-            var longReceiptHandle = GenerateReceiptHandle(S3_BUCKET_NAME, s3Key, handleTail);
+            var longReceiptHandle = GenerateReceiptHandle(S3_BUCKET_NAME, s3Key, Constants.HandleTail);
             var entries = Enumerable.Repeat(0, 3).Select(_ => new DeleteMessageBatchRequestEntry(Guid.NewGuid().ToString("N"), longReceiptHandle)).ToList();
             client.DeleteMessageBatch(new DeleteMessageBatchRequest(SQS_QUEUE_NAME, entries));
             s3Mock.Verify(m => m.DeleteObject(It.Is<string>(s => s.Equals(S3_BUCKET_NAME)), It.Is<string>(s => s.Equals(s3Key))), Times.Exactly(3));
-            sqsMock.Verify(m => m.DeleteMessageBatch(It.Is<DeleteMessageBatchRequest>(r => r.Entries.All(e => e.ReceiptHandle.Equals(handleTail)))), Times.Once);
+            sqsMock.Verify(m => m.DeleteMessageBatch(It.Is<DeleteMessageBatchRequest>(r => r.Entries.All(e => e.ReceiptHandle.Equals(Constants.HandleTail)))), Times.Once);
         }
 
         [Test]
         public async Task Long_Messages_Async_They_Are_Deleted_From_S3_And_SQS()
         {
-            var handleTail = "_handle_";
             var s3Key = Guid.NewGuid().ToString("N");
-            var longReceiptHandle = GenerateReceiptHandle(S3_BUCKET_NAME, s3Key, handleTail);
+            var longReceiptHandle = GenerateReceiptHandle(S3_BUCKET_NAME, s3Key, Constants.HandleTail);
             var entries = Enumerable.Repeat(0, 3).Select(_ => new DeleteMessageBatchRequestEntry(Guid.NewGuid().ToString("N"), longReceiptHandle)).ToList();
             await client.DeleteMessageBatchAsync(new DeleteMessageBatchRequest(SQS_QUEUE_NAME, entries));
             s3Mock.Verify(m => m.DeleteObjectAsync(It.Is<string>(s => s.Equals(S3_BUCKET_NAME)), It.Is<string>(s => s.Equals(s3Key)), It.IsAny<CancellationToken>()), Times.Exactly(3));
-            sqsMock.Verify(m => m.DeleteMessageBatchAsync(It.Is<DeleteMessageBatchRequest>(r => r.Entries.All(e => e.ReceiptHandle.Equals(handleTail))), It.IsAny<CancellationToken>()), Times.Once);
+            sqsMock.Verify(m => m.DeleteMessageBatchAsync(It.Is<DeleteMessageBatchRequest>(r => r.Entries.All(e => e.ReceiptHandle.Equals(Constants.HandleTail))), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Test]
+        public void Long_Messages_They_Are_Deleted_From_SQS_Only_If_RetainS3Messages_Configured()
+        {
+            var extendedClient = new AmazonSQSExtendedClient(
+                sqsMock.Object,
+                new ExtendedClientConfiguration()
+                    .WithLargePayloadSupportEnabled(s3Mock.Object, S3_BUCKET_NAME)
+                    .WithRetainS3Messages(true));
+            var s3Key = Guid.NewGuid().ToString("N");
+            var longReceiptHandle = GenerateReceiptHandle(S3_BUCKET_NAME, s3Key, Constants.HandleTail);
+            var entries = Enumerable.Repeat(0, 3).Select(_ => new DeleteMessageBatchRequestEntry(Guid.NewGuid().ToString("N"), longReceiptHandle)).ToList();
+            extendedClient.DeleteMessageBatch(new DeleteMessageBatchRequest(SQS_QUEUE_NAME, entries));
+            s3Mock.Verify(m => m.DeleteObject(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+            sqsMock.Verify(m => m.DeleteMessageBatch(It.Is<DeleteMessageBatchRequest>(r => r.Entries.All(e => e.ReceiptHandle.Equals(Constants.HandleTail)))), Times.Once);
+        }
+
+        [Test]
+        public async Task Long_Messages_Async_They_Are_Deleted_From_SQS_Only_If_RetainS3Messages_Configured()
+        {
+            var extendedClient = new AmazonSQSExtendedClient(
+                sqsMock.Object,
+                new ExtendedClientConfiguration()
+                    .WithLargePayloadSupportEnabled(s3Mock.Object, S3_BUCKET_NAME)
+                    .WithRetainS3Messages(true));
+            var s3Key = Guid.NewGuid().ToString("N");
+            var longReceiptHandle = GenerateReceiptHandle(S3_BUCKET_NAME, s3Key, Constants.HandleTail);
+            var entries = Enumerable.Repeat(0, 3).Select(_ => new DeleteMessageBatchRequestEntry(Guid.NewGuid().ToString("N"), longReceiptHandle)).ToList();
+            await extendedClient.DeleteMessageBatchAsync(new DeleteMessageBatchRequest(SQS_QUEUE_NAME, entries));
+            s3Mock.Verify(m => m.DeleteObjectAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+            sqsMock.Verify(m => m.DeleteMessageBatchAsync(It.Is<DeleteMessageBatchRequest>(r => r.Entries.All(e => e.ReceiptHandle.Equals(Constants.HandleTail))), It.IsAny<CancellationToken>()), Times.Once);
         }
 
         [Test]
         public void Short_Messages_They_Are_Deleted_From_SQS_Only()
         {
-            var handleTail = "_handle_";
-            var entries = Enumerable.Repeat(0, 3).Select(_ => new DeleteMessageBatchRequestEntry(Guid.NewGuid().ToString("N"), handleTail)).ToList();
+            var entries = Enumerable.Repeat(0, 3).Select(_ => new DeleteMessageBatchRequestEntry(Guid.NewGuid().ToString("N"), Constants.HandleTail)).ToList();
             client.DeleteMessageBatch(new DeleteMessageBatchRequest(SQS_QUEUE_NAME, entries));
             s3Mock.Verify(m => m.DeleteObject(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
-            sqsMock.Verify(m => m.DeleteMessageBatch(It.Is<DeleteMessageBatchRequest>(r => r.Entries.All(e => e.ReceiptHandle.Equals(handleTail)))), Times.Once);
+            sqsMock.Verify(m => m.DeleteMessageBatch(It.Is<DeleteMessageBatchRequest>(r => r.Entries.All(e => e.ReceiptHandle.Equals(Constants.HandleTail)))), Times.Once);
         }
 
         [Test]
         public async Task Short_Messages_Async_They_Are_Deleted_From_SQS_Only()
         {
-            var handleTail = "_handle_";
-            var entries = Enumerable.Repeat(0, 3).Select(_ => new DeleteMessageBatchRequestEntry(Guid.NewGuid().ToString("N"), handleTail)).ToList();
+            var entries = Enumerable.Repeat(0, 3).Select(_ => new DeleteMessageBatchRequestEntry(Guid.NewGuid().ToString("N"), Constants.HandleTail)).ToList();
             await client.DeleteMessageBatchAsync(new DeleteMessageBatchRequest(SQS_QUEUE_NAME, entries));
             s3Mock.Verify(m => m.DeleteObjectAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
-            sqsMock.Verify(m => m.DeleteMessageBatchAsync(It.Is<DeleteMessageBatchRequest>(r => r.Entries.All(e => e.ReceiptHandle.Equals(handleTail))), It.IsAny<CancellationToken>()), Times.Once);
+            sqsMock.Verify(m => m.DeleteMessageBatchAsync(It.Is<DeleteMessageBatchRequest>(r => r.Entries.All(e => e.ReceiptHandle.Equals(Constants.HandleTail))), It.IsAny<CancellationToken>()), Times.Once);
         }
     }
 }

--- a/src/Amazon.SQS.ExtendedClient.Tests/When_Extended_Client_Deletes.cs
+++ b/src/Amazon.SQS.ExtendedClient.Tests/When_Extended_Client_Deletes.cs
@@ -13,39 +13,67 @@
         [Test]
         public void Long_Message_It_Is_Deleted_From_s3()
         {
-            var handleTail = "_handle_";
             var s3Key = Guid.NewGuid().ToString("N");
-            var longReceiptHandle = GenerateReceiptHandle(S3_BUCKET_NAME, s3Key, handleTail);
+            var longReceiptHandle = GenerateReceiptHandle(S3_BUCKET_NAME, s3Key, Constants.HandleTail);
             client.DeleteMessage(new DeleteMessageRequest(SQS_QUEUE_NAME, longReceiptHandle));
             s3Mock.Verify(m => m.DeleteObject(It.Is<string>(s => s.Equals(S3_BUCKET_NAME)), It.Is<string>(s => s.Equals(s3Key))));
-            sqsMock.Verify(m => m.DeleteMessage(It.Is<DeleteMessageRequest>(r => r.QueueUrl.Equals(SQS_QUEUE_NAME) && r.ReceiptHandle.Equals(handleTail))));
+            sqsMock.Verify(m => m.DeleteMessage(It.Is<DeleteMessageRequest>(r => r.QueueUrl.Equals(SQS_QUEUE_NAME) && r.ReceiptHandle.Equals(Constants.HandleTail))));
         }
 
         [Test]
         public async Task Long_Message_Async_It_Is_Deleted_From_s3()
         {
-            var handleTail = "_handle_";
             var s3Key = Guid.NewGuid().ToString("N");
-            var longReceiptHandle = GenerateReceiptHandle(S3_BUCKET_NAME, s3Key, handleTail);
+            var longReceiptHandle = GenerateReceiptHandle(S3_BUCKET_NAME, s3Key, Constants.HandleTail);
             await client.DeleteMessageAsync(new DeleteMessageRequest(SQS_QUEUE_NAME, longReceiptHandle));
             s3Mock.Verify(m => m.DeleteObjectAsync(It.Is<string>(s => s.Equals(S3_BUCKET_NAME)), It.Is<string>(s => s.Equals(s3Key)), It.IsAny<CancellationToken>()));
-            sqsMock.Verify(m => m.DeleteMessageAsync(It.Is<DeleteMessageRequest>(r => r.QueueUrl.Equals(SQS_QUEUE_NAME) && r.ReceiptHandle.Equals(handleTail)), It.IsAny<CancellationToken>()));
+            sqsMock.Verify(m => m.DeleteMessageAsync(It.Is<DeleteMessageRequest>(r => r.QueueUrl.Equals(SQS_QUEUE_NAME) && r.ReceiptHandle.Equals(Constants.HandleTail)), It.IsAny<CancellationToken>()));
+        }
+
+        [Test]
+        public void Long_Message_It_Is_NotDeleted_From_s3_When_RetainS3Messages_Is_Set()
+        {
+            var extendedClient = new AmazonSQSExtendedClient(
+                sqsMock.Object,
+                new ExtendedClientConfiguration()
+                    .WithLargePayloadSupportEnabled(s3Mock.Object, S3_BUCKET_NAME)
+                    .WithRetainS3Messages(true));
+            var s3Key = Guid.NewGuid().ToString("N");
+            var longReceiptHandle = GenerateReceiptHandle(S3_BUCKET_NAME, s3Key, Constants.HandleTail);
+            extendedClient.DeleteMessage(new DeleteMessageRequest(SQS_QUEUE_NAME, longReceiptHandle));
+            s3Mock.Verify(m => m.DeleteObject(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+            sqsMock.Verify(m => m.DeleteMessage(It.Is<DeleteMessageRequest>(r => r.QueueUrl.Equals(SQS_QUEUE_NAME) && r.ReceiptHandle.Equals(Constants.HandleTail))));
+        }
+
+        [Test]
+        public async Task Long_Message_Async_It_Is_Deleted_From_s3_When_RetainS3Messages_Is_Set()
+        {
+            var extendedClient = new AmazonSQSExtendedClient(
+                sqsMock.Object,
+                new ExtendedClientConfiguration()
+                    .WithLargePayloadSupportEnabled(s3Mock.Object, S3_BUCKET_NAME)
+                    .WithRetainS3Messages(true));
+            var s3Key = Guid.NewGuid().ToString("N");
+            var longReceiptHandle = GenerateReceiptHandle(S3_BUCKET_NAME, s3Key, Constants.HandleTail);
+            await extendedClient.DeleteMessageAsync(new DeleteMessageRequest(SQS_QUEUE_NAME, longReceiptHandle));
+            s3Mock.Verify(m => m.DeleteObjectAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+            sqsMock.Verify(m => m.DeleteMessageAsync(It.Is<DeleteMessageRequest>(r => r.QueueUrl.Equals(SQS_QUEUE_NAME) && r.ReceiptHandle.Equals(Constants.HandleTail)), It.IsAny<CancellationToken>()));
         }
 
         [Test]
         public void Short_Message_It_Is_Deleted_Only_From_Queue()
         {
-            client.DeleteMessage(new DeleteMessageRequest(SQS_QUEUE_NAME, "handle"));
+            client.DeleteMessage(new DeleteMessageRequest(SQS_QUEUE_NAME, Constants.HandleTail));
             s3Mock.Verify(m => m.DeleteObject(It.IsAny<string>(), It.IsAny<string>()), Times.Never());
-            sqsMock.Verify(m => m.DeleteMessage(It.Is<DeleteMessageRequest>(r => r.QueueUrl.Equals(SQS_QUEUE_NAME) && r.ReceiptHandle.Equals("handle"))));
+            sqsMock.Verify(m => m.DeleteMessage(It.Is<DeleteMessageRequest>(r => r.QueueUrl.Equals(SQS_QUEUE_NAME) && r.ReceiptHandle.Equals(Constants.HandleTail))));
         }
 
         [Test]
         public async Task Short_Message_Async_It_Is_Deleted_Only_From_Queue()
         {
-            await client.DeleteMessageAsync(new DeleteMessageRequest(SQS_QUEUE_NAME, "handle"));
+            await client.DeleteMessageAsync(new DeleteMessageRequest(SQS_QUEUE_NAME, Constants.HandleTail));
             s3Mock.Verify(m => m.DeleteObjectAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never());
-            sqsMock.Verify(m => m.DeleteMessageAsync(It.Is<DeleteMessageRequest>(r => r.QueueUrl.Equals(SQS_QUEUE_NAME) && r.ReceiptHandle.Equals("handle")), It.IsAny<CancellationToken>()));
+            sqsMock.Verify(m => m.DeleteMessageAsync(It.Is<DeleteMessageRequest>(r => r.QueueUrl.Equals(SQS_QUEUE_NAME) && r.ReceiptHandle.Equals(Constants.HandleTail)), It.IsAny<CancellationToken>()));
         }
     }
 }

--- a/src/Amazon.SQS.ExtendedClient/AmazonSQSExtendedClient.cs
+++ b/src/Amazon.SQS.ExtendedClient/AmazonSQSExtendedClient.cs
@@ -231,7 +231,11 @@
 
             if (IsS3ReceiptHandle(deleteMessageRequest.ReceiptHandle))
             {
-                DeleteMessagePayloadFromS3(deleteMessageRequest.ReceiptHandle);
+                if (!clientConfiguration.RetainS3Messages)
+                {
+                    DeleteMessagePayloadFromS3(deleteMessageRequest.ReceiptHandle);
+                }
+                
                 deleteMessageRequest.ReceiptHandle = GetOriginalReceiptHandle(deleteMessageRequest.ReceiptHandle);
             }
 
@@ -257,7 +261,11 @@
 
             if (IsS3ReceiptHandle(deleteMessageRequest.ReceiptHandle))
             {
-                await DeleteMessagePayloadFromS3Async(deleteMessageRequest.ReceiptHandle, cancellationToken).ConfigureAwait(false);
+                if (!clientConfiguration.RetainS3Messages)
+                {
+                    await DeleteMessagePayloadFromS3Async(deleteMessageRequest.ReceiptHandle, cancellationToken).ConfigureAwait(false);
+                }
+                
                 deleteMessageRequest.ReceiptHandle = GetOriginalReceiptHandle(deleteMessageRequest.ReceiptHandle);
             }
 
@@ -283,7 +291,11 @@
 
             foreach (var entry in deleteMessageBatchRequest.Entries.Where(entry => IsS3ReceiptHandle(entry.ReceiptHandle)))
             {
-                DeleteMessagePayloadFromS3(entry.ReceiptHandle);
+                if (!clientConfiguration.RetainS3Messages)
+                {
+                    DeleteMessagePayloadFromS3(entry.ReceiptHandle);
+                }
+                
                 entry.ReceiptHandle = GetOriginalReceiptHandle(entry.ReceiptHandle);
             }
 
@@ -309,7 +321,11 @@
 
             foreach (var entry in deleteMessageBatchRequest.Entries.Where(entry => IsS3ReceiptHandle(entry.ReceiptHandle)))
             {
-                await DeleteMessagePayloadFromS3Async(entry.ReceiptHandle, cancellationToken).ConfigureAwait(false);
+                if (!clientConfiguration.RetainS3Messages)
+                {
+                    await DeleteMessagePayloadFromS3Async(entry.ReceiptHandle, cancellationToken).ConfigureAwait(false);
+                }
+                
                 entry.ReceiptHandle = GetOriginalReceiptHandle(entry.ReceiptHandle);
             }
 

--- a/src/Amazon.SQS.ExtendedClient/ExtendedClientConfiguration.cs
+++ b/src/Amazon.SQS.ExtendedClient/ExtendedClientConfiguration.cs
@@ -35,6 +35,8 @@
 
         public IS3KeyPovider S3KeyPovider { get; private set; }
 
+        public bool RetainS3Messages { get; set; }
+
         public ExtendedClientConfiguration WithLargePayloadSupportEnabled(IAmazonS3 s3, string s3BucketName)
         {
             if (s3 == null)
@@ -87,6 +89,12 @@
             }
 
             this.S3KeyPovider = provider;
+            return this;
+        }
+
+        public ExtendedClientConfiguration WithRetainS3Messages(bool value)
+        {
+            this.RetainS3Messages = value;
             return this;
         }
     }


### PR DESCRIPTION
Sometimes it's useful for history purposes to keep messages in S3,
when they are removed from SQS.
They will be deleted by S3 retention policy.