### PR TITLE
Update AWS packages to the latest versions

### DIFF
--- a/src/Amazon.SQS.ExtendedClient.sln.DotSettings
+++ b/src/Amazon.SQS.ExtendedClient.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=SQS/@EntryIndexedValue">SQS</s:String></wpf:ResourceDictionary>

--- a/src/Amazon.SQS.ExtendedClient/Amazon.SQS.ExtendedClient.csproj
+++ b/src/Amazon.SQS.ExtendedClient/Amazon.SQS.ExtendedClient.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.6</TargetFrameworks>
-    <AssemblyVersion>1.0.0</AssemblyVersion>
+    <TargetFrameworks>netstandard1.3</TargetFrameworks>
+    <AssemblyVersion>1.0.1</AssemblyVersion>
     <AssemblyFileVersion>1.0.0</AssemblyFileVersion>
     <AssemblyTitle>Amazon.SQS.ExtendedClient</AssemblyTitle>
     <Description>Extension to Amazon SQS that adds support for sending and receiving messages greater than 256K</Description>
@@ -13,12 +13,13 @@
     <PackageLicenseUrl>https://github.com/raol/amazon-sqs-net-extended-client-lib/blob/master/LICENSE</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/raol/amazon-sqs-net-extended-client-lib</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
+    <Version>1.0.1</Version>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" Version="3.3.18.1" />
-    <PackageReference Include="AWSSDK.S3" Version="3.3.11.2" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.3.2.9" />
+    <PackageReference Include="AWSSDK.Core" Version="3.3.21.6" />
+    <PackageReference Include="AWSSDK.S3" Version="3.3.16.2" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.3.3.2" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
   </ItemGroup>
 

--- a/src/Amazon.SQS.ExtendedClient/AmazonSQSExtendedClientBase.cs
+++ b/src/Amazon.SQS.ExtendedClient/AmazonSQSExtendedClientBase.cs
@@ -142,6 +142,11 @@ namespace Amazon.SQS.ExtendedClient
             return amazonSqsToBeExtended.ListQueuesAsync(request, cancellationToken);
         }
 
+        public Task<ListQueueTagsResponse> ListQueueTagsAsync(ListQueueTagsRequest request, CancellationToken cancellationToken = new CancellationToken())
+        {
+            return amazonSqsToBeExtended.ListQueueTagsAsync(request, cancellationToken);
+        }
+
         public Task<PurgeQueueResponse> PurgeQueueAsync(string queueUrl, CancellationToken cancellationToken = default(CancellationToken))
         {
             return amazonSqsToBeExtended.PurgeQueueAsync(queueUrl, cancellationToken);
@@ -200,6 +205,16 @@ namespace Amazon.SQS.ExtendedClient
         public Task<SetQueueAttributesResponse> SetQueueAttributesAsync(SetQueueAttributesRequest request, CancellationToken cancellationToken = default(CancellationToken))
         {
             return amazonSqsToBeExtended.SetQueueAttributesAsync(request, cancellationToken);
+        }
+
+        public Task<TagQueueResponse> TagQueueAsync(TagQueueRequest request, CancellationToken cancellationToken = new CancellationToken())
+        {
+            return amazonSqsToBeExtended.TagQueueAsync(request, cancellationToken);
+        }
+
+        public Task<UntagQueueResponse> UntagQueueAsync(UntagQueueRequest request, CancellationToken cancellationToken = new CancellationToken())
+        {
+            return amazonSqsToBeExtended.UntagQueueAsync(request, cancellationToken);
         }
 
         public IClientConfig Config => amazonSqsToBeExtended.Config;


### PR DESCRIPTION
Also since AWSSDK.Core uses nestandard1.3 as a dependency
used it too instead of 1.6