### PR TITLE
Added ability to retrieve message details in case of failed to get data from S3

### DIFF
--- a/src/Amazon.SQS.ExtendedClient/AmazonSQSExtendedClient.cs
+++ b/src/Amazon.SQS.ExtendedClient/AmazonSQSExtendedClient.cs
@@ -105,11 +105,20 @@
             {
                 if (message.MessageAttributes.TryGetValue(SQSExtendedClientConstants.RESERVED_ATTRIBUTE_NAME, out _))
                 {
-                    var messageS3Pointer = ReadMessageS3PointerFromJson(message.Body);
-                    var originalMessageBody = await GetTextFromS3Async(messageS3Pointer.S3BucketName, messageS3Pointer.S3Key, cancellationToken).ConfigureAwait(false);
-                    message.Body = originalMessageBody;
-                    message.ReceiptHandle = EmbedS3PointerInReceiptHandle(message.ReceiptHandle, messageS3Pointer.S3BucketName, messageS3Pointer.S3Key);
-                    message.MessageAttributes.Remove(SQSExtendedClientConstants.RESERVED_ATTRIBUTE_NAME);
+                    try
+                    {
+                        var messageS3Pointer = ReadMessageS3PointerFromJson(message.Body);
+                        var originalMessageBody = await GetTextFromS3Async(messageS3Pointer.S3BucketName, messageS3Pointer.S3Key, cancellationToken).ConfigureAwait(false);
+                        message.Body = originalMessageBody;
+                        message.ReceiptHandle = EmbedS3PointerInReceiptHandle(message.ReceiptHandle, messageS3Pointer.S3BucketName, messageS3Pointer.S3Key);
+                        message.MessageAttributes.Remove(SQSExtendedClientConstants.RESERVED_ATTRIBUTE_NAME);
+                    }
+                    catch (AmazonClientException amazonClientException)
+                    {
+                        amazonClientException.Data.Add(nameof(Message.MessageId), message.MessageId);
+                        amazonClientException.Data.Add(nameof(Message.ReceiptHandle), message.ReceiptHandle);
+                        throw;
+                    }
                 }
             }
 


### PR DESCRIPTION
I found your library very helpful in case of bigger payloads. When doing tests I found some scenarios that cannot be covered using existing implementation because the lack of information about messages received from the Amazon service (sqs). 
In my scenario I would like to be able to get the receipt handle and delete the message when I get AmazonS3Exception saying the payload is gone (somehow removed) while receiving the message.

Hope you will find my PR usefull.